### PR TITLE
Dail send nomi resolves #711

### DIFF
--- a/Script Files/DAIL/DAIL - SEND NOMI.vbs
+++ b/Script Files/DAIL/DAIL - SEND NOMI.vbs
@@ -1,4 +1,4 @@
-OPTION EXPLICIT
+'OPTION EXPLICIT
 name_of_script = "DAIL - SEND NOMI.vbs"
 start_time = timer
 
@@ -50,11 +50,11 @@ END IF
 'END OF GLOBAL VARIABLES----------------------------------------------------------------------------------------------------
 
 'Declaring variables
-DIM ButtonPressed
-DIM interview_date
-DIM interview_time
-DIM recert_forms_confirm
-DIM result_of_msgbox
+'DIM ButtonPressed
+'DIM interview_date
+'DIM interview_time
+'DIM recert_forms_confirm
+'DIM result_of_msgbox
 
 '------------------THIS SCRIPT IS DESIGNED TO BE RUN FROM THE DAIL SCRUBBER.
 '------------------As such, it does NOT include protections to be ran independently.

--- a/Script Files/DAIL/DAIL - SEND NOMI.vbs
+++ b/Script Files/DAIL/DAIL - SEND NOMI.vbs
@@ -1,0 +1,130 @@
+'OPTION EXPLICIT
+
+name_of_script = "DAIL - SEND NOMI.vbs"
+start_time = timer
+
+DIM name_of_script
+DIM start_time
+DIM FuncLib_URL
+DIM run_locally
+DIM default_directory
+DIM beta_agency
+DIM req
+DIM fso
+DIM row
+
+'LOADING FUNCTIONS LIBRARY FROM GITHUB REPOSITORY===========================================================================
+IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded once
+	IF run_locally = FALSE or run_locally = "" THEN		'If the scripts are set to run locally, it skips this and uses an FSO below.
+		IF default_directory = "C:\DHS-MAXIS-Scripts\Script Files\" THEN			'If the default_directory is C:\DHS-MAXIS-Scripts\Script Files, you're probably a scriptwriter and should use the master branch.
+			FuncLib_URL = "https://raw.githubusercontent.com/MN-Script-Team/BZS-FuncLib/master/MASTER%20FUNCTIONS%20LIBRARY.vbs"
+		ELSEIF beta_agency = "" or beta_agency = True then							'If you're a beta agency, you should probably use the beta branch.
+			FuncLib_URL = "https://raw.githubusercontent.com/MN-Script-Team/BZS-FuncLib/BETA/MASTER%20FUNCTIONS%20LIBRARY.vbs"
+		Else																		'Everyone else should use the release branch.
+			FuncLib_URL = "https://raw.githubusercontent.com/MN-Script-Team/BZS-FuncLib/RELEASE/MASTER%20FUNCTIONS%20LIBRARY.vbs"
+		End if
+		SET req = CreateObject("Msxml2.XMLHttp.6.0")				'Creates an object to get a FuncLib_URL
+		req.open "GET", FuncLib_URL, FALSE							'Attempts to open the FuncLib_URL
+		req.send													'Sends request
+		IF req.Status = 200 THEN									'200 means great success
+			Set fso = CreateObject("Scripting.FileSystemObject")	'Creates an FSO
+			Execute req.responseText								'Executes the script code
+		ELSE														'Error message, tells user to try to reach github.com, otherwise instructs to contact Veronica with details (and stops script).
+			MsgBox 	"Something has gone wrong. The code stored on GitHub was not able to be reached." & vbCr &_ 
+					vbCr & _
+					"Before contacting Veronica Cary, please check to make sure you can load the main page at www.GitHub.com." & vbCr &_
+					vbCr & _
+					"If you can reach GitHub.com, but this script still does not work, ask an alpha user to contact Veronica Cary and provide the following information:" & vbCr &_
+					vbTab & "- The name of the script you are running." & vbCr &_
+					vbTab & "- Whether or not the script is ""erroring out"" for any other users." & vbCr &_
+					vbTab & "- The name and email for an employee from your IT department," & vbCr & _
+					vbTab & vbTab & "responsible for network issues." & vbCr &_
+					vbTab & "- The URL indicated below (a screenshot should suffice)." & vbCr &_
+					vbCr & _
+					"Veronica will work with your IT department to try and solve this issue, if needed." & vbCr &_ 
+					vbCr &_
+					"URL: " & FuncLib_URL
+					script_end_procedure("Script ended due to error connecting to GitHub.")
+		END IF
+	ELSE
+		FuncLib_URL = "C:\BZS-FuncLib\MASTER FUNCTIONS LIBRARY.vbs"
+		Set run_another_script_fso = CreateObject("Scripting.FileSystemObject")
+		Set fso_command = run_another_script_fso.OpenTextFile(FuncLib_URL)
+		text_from_the_other_script = fso_command.ReadAll
+		fso_command.Close
+		Execute text_from_the_other_script
+	END IF
+END IF
+'END OF GLOBAL VARIABLES----------------------------------------------------------------------------------------------------
+
+EMConnect ""
+
+'Reading date and time of recert appt. from TIKL
+EMReadScreen ***date of appt
+EMReadScreen ***time of appt
+
+'navigates to CASE/NOTE
+EMWriteScreen "n" 
+EMWriteScreen "<enter>"
+
+'checking to see if case note exists prior to recertification date listed in TIKL
+EMReadScreen post_scheduled_appt_note_check, 8, 5, 6
+EMReadScreen post_scheduled_appt_note_check, 8, 6, 6
+EMReadScreen post_scheduled_appt_note_check, 8, 7, 6
+EMReadScreen post_scheduled_appt_note_check, 8, 8, 6
+EMReadScreen post_scheduled_appt_note_check, 8, 9, 6
+EMReadScreen post_scheduled_appt_note_check, 8, 10, 6
+EMReadScreen post_scheduled_appt_note_check, 8, 11, 6
+EMReadScreen post_scheduled_appt_note_check, 8, 12, 6
+EMReadScreen post_scheduled_appt_note_check, 8, 13, 6
+EMReadScreen post_scheduled_appt_note_check, 8, 14, 6
+EMReadScreen post_scheduled_appt_note_check, 8, 15, 6
+EMReadScreen post_scheduled_appt_note_check, 8, 16, 6
+EMReadScreen post_scheduled_appt_note_check, 8, 17, 6
+EMReadScreen post_scheduled_appt_note_check, 8, 18, 6
+
+If post_scheduled_appt_note_check <> appt_date or date after**** Then
+
+
+
+
+'THE CASE NOTE----------------------------------------------------------------------------------------------------
+'Navigates to a blank case note
+Call start_a_blank_case_note
+'Writes the case note
+Call write_variable_in_CASE_NOTE ("**Client missed SNAP recertification interview**")
+Call write_bullet_and_variable_in_CASE_NOTE "Appointment was scheduled for" & date_of_missed_interview & " at " & time_of_missed_interview & "."
+Call write_variable_in_CASE_NOTE "* A SPEC/MEMO has been sent to the client informing them of missed interview."
+Call write_variable_in_CASE_NOTE ("---")
+Call write_variable_in_CASE_NOTE (worker_signature)
+
+
+'THE ER NOMI SPEC/MEMO----------------------------------------------------------------------------------------------------
+'Navigates into SPEC/MEMO
+call navigate_to_screen("SPEC", "MEMO")
+
+'Checks to make sure we're past the SELF menu+
+EMReadScreen still_self, 27, 2, 28 
+If still_self = "Select Function Menu (SELF)" then script_end_procedure("Script was not able to get past SELF menu. Is case in background?")
+
+'Creates a new MEMO. If it's unable the script will stop.
+PF5
+EMReadScreen memo_display_check, 12, 2, 33
+If memo_display_check = "Memo Display" then script_end_procedure("You are not able to go into update mode. Did you enter in inquiry by mistake? Please try again in production.")
+EMWriteScreen "x", 5, 10
+transmit
+
+'Writes the info into the MEMO.
+EMSetCursor 3, 15
+Call write_variable_in_SPEC_MEMO("************************************************************")
+Call write_variable_in_SPEC_MEMO("You have missed your Food Support interview that was scheduled for " & date_of_missed_interview & " at " & time_of_missed_interview & ".")
+Call write_variable_in_SPEC_MEMO("Please contact your worker at the telephone number listed below to reschedule the required Food Support interview.")
+Call write_variable_in_SPEC_MEMO("The Combined Application Form (DHS-5223), the interview by phone or in the office, and the mandatory verifications needed to process your recertification must be completed by " & last_day_for_recert & " or your Food Support case will Auto-Close on this date." & "<newline>"
+Call write_variable_in_SPEC_MEMO("************************************************************")
+PF4	
+
+'Pop up for worker informing them NOMI has been sent for missed SNAP/MFIP ER	
+MsgBox "Success! A SPEC/MEMO has been sent with the correct language for a missed SNAP recert. A case note has been made."
+
+script_end_procedure("")
+

--- a/Script Files/DAIL/DAIL - SEND NOMI.vbs
+++ b/Script Files/DAIL/DAIL - SEND NOMI.vbs
@@ -65,23 +65,24 @@ DIM interview_time
 DIM recert_forms_confirm
 DIM result_of_msgbox
 
+'------------------THIS SCRIPT IS DESIGNED TO BE RUN FROM THE DAIL SCRUBBER.
+'------------------As such, it does NOT include protections to be ran independently.
 
-'DAIL SCRUBBER START----------------------------------------------------------------------------------------------------
 EMConnect ""
 
 'Reading date and time of recert appt. from TIKL
-~*~*~CLIENT HAD RECERT INTERVIEW APPOINTMENT. IF MISSED SEND NOMI.
-EMReadScreen interview_date
-EMReadScreen interview_time   
-PF3 
+Dail message ~*~*~CLIENT HAD RECERT INTERVIEW APPOINTMENT. IF MISSED SEND NOMI.
+EMReadScreen interview_date, 10, *****
+EMReadScreen interview_time, 8?, *****  
 
-'navigates to CASE/NOTE
+
+'navigates to CASE/NOTE to user can see if interview has been completed or not
 EMSendKey "n" 
 transmit
 
-
-recert_forms_confirm = MsgBox("The SNAP NOMI recertification SPEC/MEMO is not to be used when the SNAP recipient never contacts the agency and no CAF is received.  Press Yes if forms provided OR contact was made by the recipient.") & _ 
-	VbNewLine & ("Press No if no forms provided") & vbNewLine &("Cancel to end the script.", vbYesNoCancel)
+'Msgbox asking the user to confirm if the client has sent a CAF or if no contact has been made by the client
+recert_forms_confirm = MsgBox("The SNAP NOMI recertification SPEC/MEMO is not to be sent when the SNAP recipient does not contact the agency about their recertification, and no CAF is received.  Press Yes if forms provided, OR contact was made by the recipient.") & _ 
+	VbNewLine & ("Press No if no forms provided") & vbNewLine & ("Cancel to end the script.", vbYesNoCancel)
 	If recert_forms_confirm = vbCancel then stopscript
 	If recert_forms_confirm = vbYes then result_of_msgbox = TRUE
 	If recert_forms_confirm = vbNo then result_of_msgbox = FALSE

--- a/Script Files/DAIL/DAIL - SEND NOMI.vbs
+++ b/Script Files/DAIL/DAIL - SEND NOMI.vbs
@@ -57,74 +57,85 @@ IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded
 END IF
 'END OF GLOBAL VARIABLES----------------------------------------------------------------------------------------------------
 
+'Declaring variables
+DIM ButtonPressed
+DIM missed_interview_dialog
+DIM completed_interview_dialog
+
+'DIALOGS----------------------------------------------------------------------------------------------------
+BeginDialog missed_interview_dialog, 0, 0, 226, 45, "Missed interview dialog"
+  ButtonGroup ButtonPressed
+    OkButton 55, 25, 50, 15
+    CancelButton 110, 25, 50, 15
+  Text 5, 10, 225, 10, "It appears this case has missed an interview.  Press OK to confirm."
+EndDialog
+
+BeginDialog completed_interview_dialog, 0, 0, 241, 45, "Completed interview dialog"
+  ButtonGroup ButtonPressed
+    OkButton 55, 25, 50, 15
+    CancelButton 110, 25, 50, 15
+  Text 5, 10, 230, 10, "It appears this case has completed an interview.  Press OK to confirm."
+EndDialog
+
+'DAIL SCRUBBER START----------------------------------------------------------------------------------------------------
 EMConnect ""
 
 'Reading date and time of recert appt. from TIKL
-EMReadScreen ***date of appt
-EMReadScreen ***time of appt
+EMReadScreen date_of_missed_interview   *********************************************************
+EMReadScreen time_of_missed_interview   *********************************************************
+PF3 
 
 'navigates to CASE/NOTE
-EMWriteScreen "n" 
-EMWriteScreen "<enter>"
+EMSendKey "n" 
+transmit
 
 'checking to see if case note exists prior to recertification date listed in TIKL
 EMReadScreen post_scheduled_appt_note_check, 8, 5, 6
-EMReadScreen post_scheduled_appt_note_check, 8, 6, 6
-EMReadScreen post_scheduled_appt_note_check, 8, 7, 6
-EMReadScreen post_scheduled_appt_note_check, 8, 8, 6
-EMReadScreen post_scheduled_appt_note_check, 8, 9, 6
-EMReadScreen post_scheduled_appt_note_check, 8, 10, 6
-EMReadScreen post_scheduled_appt_note_check, 8, 11, 6
-EMReadScreen post_scheduled_appt_note_check, 8, 12, 6
-EMReadScreen post_scheduled_appt_note_check, 8, 13, 6
-EMReadScreen post_scheduled_appt_note_check, 8, 14, 6
-EMReadScreen post_scheduled_appt_note_check, 8, 15, 6
-EMReadScreen post_scheduled_appt_note_check, 8, 16, 6
-EMReadScreen post_scheduled_appt_note_check, 8, 17, 6
-EMReadScreen post_scheduled_appt_note_check, 8, 18, 6
-
-If post_scheduled_appt_note_check <> appt_date or date after**** Then
 
 
+If post_scheduled_appt_note_check = appt_date THEN
+	completed_interview_dialog
+	cancel_confirmation
+End IF
 
-
-'THE CASE NOTE----------------------------------------------------------------------------------------------------
-'Navigates to a blank case note
-Call start_a_blank_case_note
-'Writes the case note
-Call write_variable_in_CASE_NOTE ("**Client missed SNAP recertification interview**")
-Call write_bullet_and_variable_in_CASE_NOTE "Appointment was scheduled for" & date_of_missed_interview & " at " & time_of_missed_interview & "."
-Call write_variable_in_CASE_NOTE "* A SPEC/MEMO has been sent to the client informing them of missed interview."
-Call write_variable_in_CASE_NOTE ("---")
-Call write_variable_in_CASE_NOTE (worker_signature)
-
-
-'THE ER NOMI SPEC/MEMO----------------------------------------------------------------------------------------------------
-'Navigates into SPEC/MEMO
-call navigate_to_screen("SPEC", "MEMO")
-
-'Checks to make sure we're past the SELF menu+
-EMReadScreen still_self, 27, 2, 28 
-If still_self = "Select Function Menu (SELF)" then script_end_procedure("Script was not able to get past SELF menu. Is case in background?")
-
-'Creates a new MEMO. If it's unable the script will stop.
-PF5
-EMReadScreen memo_display_check, 12, 2, 33
-If memo_display_check = "Memo Display" then script_end_procedure("You are not able to go into update mode. Did you enter in inquiry by mistake? Please try again in production.")
-EMWriteScreen "x", 5, 10
-transmit
-
-'Writes the info into the MEMO.
-EMSetCursor 3, 15
-Call write_variable_in_SPEC_MEMO("************************************************************")
-Call write_variable_in_SPEC_MEMO("You have missed your Food Support interview that was scheduled for " & date_of_missed_interview & " at " & time_of_missed_interview & ".")
-Call write_variable_in_SPEC_MEMO("Please contact your worker at the telephone number listed below to reschedule the required Food Support interview.")
-Call write_variable_in_SPEC_MEMO("The Combined Application Form (DHS-5223), the interview by phone or in the office, and the mandatory verifications needed to process your recertification must be completed by " & last_day_for_recert & " or your Food Support case will Auto-Close on this date." & "<newline>"
-Call write_variable_in_SPEC_MEMO("************************************************************")
-PF4	
-
-'Pop up for worker informing them NOMI has been sent for missed SNAP/MFIP ER	
-MsgBox "Success! A SPEC/MEMO has been sent with the correct language for a missed SNAP recert. A case note has been made."
+If post_scheduled_appt_note_check <> appt_date or date after**** THEN 
+	DO
+		missed_interview_dialog
+		cancel_confimation
+		Call proceed_confirmation(go_to_case_note)
+	Loop until go_to_case_note = TRUE
+	
+	'THE CASE NOTE----------------------------------------------------------------------------------------------------
+	'Navigates to a blank case note
+	Call start_a_blank_case_note
+	'Writes the case note
+	Call write_variable_in_CASE_NOTE ("**Client missed SNAP recertification interview**")
+	Call write_bullet_and_variable_in_CASE_NOTE "Appointment was scheduled for" & date_of_missed_interview & " at " & time_of_missed_interview & "."
+	Call write_variable_in_CASE_NOTE "* A SPEC/MEMO has been sent to the client informing them of missed interview."
+	Call write_variable_in_CASE_NOTE ("---")
+	Call write_variable_in_CASE_NOTE (worker_signature)
+	
+	
+	'THE ER NOMI SPEC/MEMO----------------------------------------------------------------------------------------------------
+	'Navigates into SPEC/MEMO
+	call navigate_to_screen("SPEC", "MEMO")
+	'Creates a new MEMO. If it's unable the script will stop.
+	PF5
+	EMReadScreen memo_display_check, 12, 2, 33
+	If memo_display_check = "Memo Display" then script_end_procedure("You are not able to go into update mode. Did you enter in inquiry by mistake? Please try again in production.")
+	EMWriteScreen "x", 5, 10
+	transmit
+	'Writes the info into the MEMO.
+	Call write_variable_in_SPEC_MEMO("************************************************************")
+	Call write_variable_in_SPEC_MEMO("You have missed your Food Support interview that was scheduled for " & date_of_missed_interview & " at " & time_of_missed_interview & ".")
+	Call write_variable_in_SPEC_MEMO("Please contact your worker at the telephone number listed below to reschedule the required Food Support interview.")
+	Call write_variable_in_SPEC_MEMO("The Combined Application Form (DHS-5223), the interview by phone or in the office, and the mandatory verifications needed to process your recertification must be completed by " & last_day_for_recert & " or your Food Support case will Auto-Close on this date." & "<newline>"
+	Call write_variable_in_SPEC_MEMO("************************************************************")
+	PF4	
+	PF3
+	'Pop up for worker informing them NOMI has been sent for missed SNAP/MFIP ER	
+	MsgBox "Success! A SPEC/MEMO has been sent with the correct language for a missed SNAP recert. A case note has been made."
+END IF
 
 script_end_procedure("")
 

--- a/Script Files/DAIL/DAIL - SEND NOMI.vbs
+++ b/Script Files/DAIL/DAIL - SEND NOMI.vbs
@@ -1,17 +1,8 @@
 OPTION EXPLICIT
-
 name_of_script = "DAIL - SEND NOMI.vbs"
 start_time = timer
 
-DIM name_of_script
-DIM start_time
-DIM FuncLib_URL
-DIM run_locally
-DIM default_directory
-DIM beta_agency
-DIM req
-DIM fso
-DIM row
+DIM name_of_script, start_time, FuncLib_URL, run_locally, default_directory, beta_agency, req, fso, row
 
 'LOADING FUNCTIONS LIBRARY FROM GITHUB REPOSITORY===========================================================================
 IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded once
@@ -71,17 +62,16 @@ DIM result_of_msgbox
 EMConnect ""
 
 'Reading date and time of recert appt. from TIKL
-Dail message ~*~*~CLIENT HAD RECERT INTERVIEW APPOINTMENT. IF MISSED SEND NOMI.
-EMReadScreen interview_date, 10, *****
-EMReadScreen interview_time, 8?, *****  
-
+'Dail message that should be read is: "~*~*~CLIENT HAD RECERT INTERVIEW AT" This is the part that is static in the DAIL message
+EMReadScreen interview_date, 10, 17, 57
+EMReadScreen interview_time, 8, 17, 71
 
 'navigates to CASE/NOTE to user can see if interview has been completed or not
 EMSendKey "n" 
 transmit
 
 'Msgbox asking the user to confirm if the client has sent a CAF or if no contact has been made by the client
-recert_forms_confirm = MsgBox("The SNAP NOMI recertification SPEC/MEMO is not to be sent when the SNAP recipient does not contact the agency about their recertification, and no CAF is received.  Press Yes if forms provided, OR contact was made by the recipient.") & _ 
+recert_forms_confirm = MsgBox("The SNAP NOMI recertification SPEC/MEMO is ONLY to be sent when the SNAP recipient does not contact the agency about their recertification, and no CAF is received.  Press Yes if forms provided, OR contact was made by the recipient.") & _ 
 	VbNewLine & ("Press No if no forms provided") & vbNewLine & ("Cancel to end the script.", vbYesNoCancel)
 	If recert_forms_confirm = vbCancel then stopscript
 	If recert_forms_confirm = vbYes then result_of_msgbox = TRUE

--- a/Script Files/DAIL/DAIL - SEND NOMI.vbs
+++ b/Script Files/DAIL/DAIL - SEND NOMI.vbs
@@ -1,4 +1,4 @@
-'OPTION EXPLICIT
+OPTION EXPLICIT
 
 name_of_script = "DAIL - SEND NOMI.vbs"
 start_time = timer
@@ -16,7 +16,8 @@ DIM row
 'LOADING FUNCTIONS LIBRARY FROM GITHUB REPOSITORY===========================================================================
 IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded once
 	IF run_locally = FALSE or run_locally = "" THEN		'If the scripts are set to run locally, it skips this and uses an FSO below.
-		IF default_directory = "C:\DHS-MAXIS-Scripts\Script Files\" THEN			'If the default_directory is C:\DHS-MAXIS-Scripts\Script Files, you're probably a scriptwriter and should use the master branch.
+		IF default_directory = "C:\DHS-MAXIS-Scripts\Script Files\" OR default_directory = "" THEN
+			'If the default_directory is C:\DHS-MAXIS-Scripts\Script Files, you're probably a scriptwriter and should use the master branch.
 			FuncLib_URL = "https://raw.githubusercontent.com/MN-Script-Team/BZS-FuncLib/master/MASTER%20FUNCTIONS%20LIBRARY.vbs"
 		ELSEIF beta_agency = "" or beta_agency = True then							'If you're a beta agency, you should probably use the beta branch.
 			FuncLib_URL = "https://raw.githubusercontent.com/MN-Script-Team/BZS-FuncLib/BETA/MASTER%20FUNCTIONS%20LIBRARY.vbs"
@@ -59,83 +60,67 @@ END IF
 
 'Declaring variables
 DIM ButtonPressed
-DIM missed_interview_dialog
-DIM completed_interview_dialog
+DIM interview_date
+DIM interview_time
+DIM recert_forms_confirm
+DIM result_of_msgbox
 
-'DIALOGS----------------------------------------------------------------------------------------------------
-BeginDialog missed_interview_dialog, 0, 0, 226, 45, "Missed interview dialog"
-  ButtonGroup ButtonPressed
-    OkButton 55, 25, 50, 15
-    CancelButton 110, 25, 50, 15
-  Text 5, 10, 225, 10, "It appears this case has missed an interview.  Press OK to confirm."
-EndDialog
-
-BeginDialog completed_interview_dialog, 0, 0, 241, 45, "Completed interview dialog"
-  ButtonGroup ButtonPressed
-    OkButton 55, 25, 50, 15
-    CancelButton 110, 25, 50, 15
-  Text 5, 10, 230, 10, "It appears this case has completed an interview.  Press OK to confirm."
-EndDialog
 
 'DAIL SCRUBBER START----------------------------------------------------------------------------------------------------
 EMConnect ""
 
 'Reading date and time of recert appt. from TIKL
-EMReadScreen date_of_missed_interview   *********************************************************
-EMReadScreen time_of_missed_interview   *********************************************************
+~*~*~CLIENT HAD RECERT INTERVIEW APPOINTMENT. IF MISSED SEND NOMI.
+EMReadScreen interview_date
+EMReadScreen interview_time   
 PF3 
 
 'navigates to CASE/NOTE
 EMSendKey "n" 
 transmit
 
-'checking to see if case note exists prior to recertification date listed in TIKL
-EMReadScreen post_scheduled_appt_note_check, 8, 5, 6
 
+recert_forms_confirm = MsgBox("The SNAP NOMI recertification SPEC/MEMO is not to be used when the SNAP recipient never contacts the agency and no CAF is received.  Press Yes if forms provided OR contact was made by the recipient.") & _ 
+	VbNewLine & ("Press No if no forms provided") & vbNewLine &("Cancel to end the script.", vbYesNoCancel)
+	If recert_forms_confirm = vbCancel then stopscript
+	If recert_forms_confirm = vbYes then result_of_msgbox = TRUE
+	If recert_forms_confirm = vbNo then result_of_msgbox = FALSE
 
-If post_scheduled_appt_note_check = appt_date THEN
-	completed_interview_dialog
-	cancel_confirmation
-End IF
-
-If post_scheduled_appt_note_check <> appt_date or date after**** THEN 
-	DO
-		missed_interview_dialog
-		cancel_confimation
-		Call proceed_confirmation(go_to_case_note)
-	Loop until go_to_case_note = TRUE
-	
-	'THE CASE NOTE----------------------------------------------------------------------------------------------------
-	'Navigates to a blank case note
-	Call start_a_blank_case_note
-	'Writes the case note
-	Call write_variable_in_CASE_NOTE ("**Client missed SNAP recertification interview**")
-	Call write_bullet_and_variable_in_CASE_NOTE "Appointment was scheduled for" & date_of_missed_interview & " at " & time_of_missed_interview & "."
-	Call write_variable_in_CASE_NOTE "* A SPEC/MEMO has been sent to the client informing them of missed interview."
-	Call write_variable_in_CASE_NOTE ("---")
-	Call write_variable_in_CASE_NOTE (worker_signature)
-	
-	
-	'THE ER NOMI SPEC/MEMO----------------------------------------------------------------------------------------------------
+If result_of_msgbox = TRUE then
 	'Navigates into SPEC/MEMO
 	call navigate_to_screen("SPEC", "MEMO")
 	'Creates a new MEMO. If it's unable the script will stop.
 	PF5
-	EMReadScreen memo_display_check, 12, 2, 33
-	If memo_display_check = "Memo Display" then script_end_procedure("You are not able to go into update mode. Did you enter in inquiry by mistake? Please try again in production.")
-	EMWriteScreen "x", 5, 10
-	transmit
 	'Writes the info into the MEMO.
 	Call write_variable_in_SPEC_MEMO("************************************************************")
-	Call write_variable_in_SPEC_MEMO("You have missed your Food Support interview that was scheduled for " & date_of_missed_interview & " at " & time_of_missed_interview & ".")
-	Call write_variable_in_SPEC_MEMO("Please contact your worker at the telephone number listed below to reschedule the required Food Support interview.")
-	Call write_variable_in_SPEC_MEMO("The Combined Application Form (DHS-5223), the interview by phone or in the office, and the mandatory verifications needed to process your recertification must be completed by " & last_day_for_recert & " or your Food Support case will Auto-Close on this date." & "<newline>"
+	Call write_variable_in_SPEC_MEMO("You have missed your SNAP interview that was scheduled for " & interview_date & " at " & interview_time & ".")
+	Call write_variable_in_SPEC_MEMO("Please contact your worker at the telephone number listed below to reschedule the required SNAP interview.")
+	Call write_variable_in_SPEC_MEMO("The renewal form, the interview by phone or in the office, and the mandatory verifications are needed to process your renewal must be completed by " & last_day_for_recert & " or your Food Support case will Auto-Close on this date.")
 	Call write_variable_in_SPEC_MEMO("************************************************************")
 	PF4	
 	PF3
-	'Pop up for worker informing them NOMI has been sent for missed SNAP/MFIP ER	
-	MsgBox "Success! A SPEC/MEMO has been sent with the correct language for a missed SNAP recert. A case note has been made."
-END IF
 
-script_end_procedure("")
+	'Navigates to a blank case note
+	start_a_blank_case_note
+	'Writes the case note
+	Call write_variable_in_CASE_NOTE ("**Client missed SNAP recertification interview**")
+	Call write_bullet_and_variable_in_CASE_NOTE "Appointment was scheduled for" & interview_date & " at " & interview_time & "."
+	Call write_variable_in_CASE_NOTE "* A SNAP NOMI for recertifications SPEC/MEMO has been sent to the client informing them of their missed interview."
+	Call write_variable_in_CASE_NOTE ("---")
+	Call write_variable_in_CASE_NOTE (worker_signature)
+	PF3
+	script_end_procedure("Success! A SNAP NOMI for recertifications SPEC/MEMO has been sent.")
+END IF 
 
+If result_of_msgbox = FALSE
+	'Navigates to a blank case note
+	start_a_blank_case_note
+	'Writes the case note
+	Call write_variable_in_CASE_NOTE ("**Client missed SNAP recertification interview**")
+	Call write_bullet_and_variable_in_CASE_NOTE "Appointment was scheduled for" & interview_date & " at " & interview_time & "."
+	Call write_variable_in_CASE_NOTE ("* A SNAP NOMI for recertifications SPEC/MEMO HAS NOT been sent. Per POLI/TEMP TE02.05.15: When there is no request for further assistance the client will receive the proper closing.")
+	Call write_variable_in_CASE_NOTE ("---")
+	Call write_variable_in_CASE_NOTE (worker_signature)
+	PF3
+	script_end_procedure("Success! A SNAP NOMI for recertifications SPEC/MEMO has NOT been sent.")
+END IF 


### PR DESCRIPTION
DAIL scrubber for sending the NOMI when a user has used the REVS scrubber to schedule appointments for SNAP based programs. 

Resolves issue #711

No blip since this has not been released yet. Also this has not been tested. 
